### PR TITLE
Consul service for discovering Kafka servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ kafka.consumer.topics=export\..*
 kafka.consumer.remove.prefix=export\.
 
 # Consul server address
-consul.server=127.0.0.1:8500
+consul.server=http://localhost:8500
 
 # Name for Kafka services inside Consul
 consul.kafka.servicename=kafka

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Consume Kafka topics and export to Prometheus
 ### Start process
 
 ```
-java -jar kafka-topic-exporter-0.0.5-jar-with-dependencies.jar config/kafka-topic-exporter.properties
+java -jar kafka-topic-exporter-0.0.6-jar-with-dependencies.jar config/kafka-topic-exporter.properties
 ```
 
 ### Configuration
@@ -28,7 +28,7 @@ kafka.consumer.topics=export\..*
 kafka.consumer.remove.prefix=export\.
 
 # Consul server address
-consul.server=http://localhost:8500
+consul.server.url=http://localhost:8500
 
 # Name for Kafka services inside Consul
 consul.kafka.servicename=kafka

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ kafka.consumer.topics=export\..*
 # RegEx for removing substring from Kafka info
 kafka.consumer.remove.prefix=export\.
 
+# Consul server address
+consul.server=127.0.0.1:8500
+
+# Name for Kafka services inside Consul
+consul.kafka.servicename=kafka
+
 ## Kafka core properties
 
 # A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.

--- a/config/kafka-topic-exporter.sample.properties
+++ b/config/kafka-topic-exporter.sample.properties
@@ -12,6 +12,14 @@ kafka.consumer.topics=export\..*
 # RegEx for removing substring from Kafka info
 kafka.consumer.remove.prefix=export\.
 
+## Consul properties
+
+# Consul server URL (including protocol: http/https)
+consul.server.url=http://localhost:8500
+
+# Consul service name for filtering the Kafka service
+consul.kafka.servicename=kafka
+
 ## Kafka core properties
 
 # A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.orbitz.consul</groupId>
+      <artifactId>consul-client</artifactId>
+      <version>1.1.1</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>jp.gr.java_conf.ogibayashi</groupId>
   <artifactId>kafka-topic-exporter</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.6-beta.2</version>
+  <version>0.0.6</version>
   <name>kafka-topic-exporter</name>
   <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>jp.gr.java_conf.ogibayashi</groupId>
   <artifactId>kafka-topic-exporter</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.5</version>
+  <version>0.0.6-beta.1</version>
   <name>kafka-topic-exporter</name>
   <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>jp.gr.java_conf.ogibayashi</groupId>
   <artifactId>kafka-topic-exporter</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.6-beta.1</version>
+  <version>0.0.6-beta.2</version>
   <name>kafka-topic-exporter</name>
   <url>http://maven.apache.org</url>
 

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -28,7 +28,7 @@ public class PropertyConfig {
     }
 
     public enum Constants {
-        CONSUL_SERVER("consul.server"),
+        CONSUL_SERVER_URL("consul.server.url"),
         CONSUL_KAFKA_SERVICENAME("consul.kafka.servicename"),
         BOOTSTRAP_SERVERS("bootstrap.servers"),
         EXPORTER_PORT("exporter.port"),
@@ -60,7 +60,7 @@ public class PropertyConfig {
     }
 
     void fixBootstrapServerIfConsulExists(Properties originalProps) {
-        String consulServer = originalProps.getProperty(Constants.CONSUL_SERVER.key);
+        String consulServer = originalProps.getProperty(Constants.CONSUL_SERVER_URL.key);
         String consulKafkaServicename = originalProps.getProperty(Constants.CONSUL_KAFKA_SERVICENAME.key);
 
         if (consulServer != null && consulKafkaServicename != null) {

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -3,8 +3,6 @@ package jp.gr.java_conf.ogibayashi.prometheus;
 import java.io.FileNotFoundException;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -50,12 +50,12 @@ public class PropertyConfig {
     }
 
     void changeBootstrapServersIfConsulServerAvailable(Properties originalProps) {
-        String consulServer = originalProps.getProperty(Constants.CONSUL_SERVER_URL.key);
+        String consulServerUrl = originalProps.getProperty(Constants.CONSUL_SERVER_URL.key);
         String consulKafkaServicename = originalProps.getProperty(Constants.CONSUL_KAFKA_SERVICENAME.key);
 
-        if (consulServer != null && consulKafkaServicename != null) {
+        if (consulServerUrl != null && !consulServerUrl.equals("") && consulKafkaServicename != null && !consulKafkaServicename.equals("")) {
             LOG.info("CONSUL: Required properties for using Consul service discovery have been detected");
-            ArrayList<String> bootstrapServersArray = getBootStrapServersFromConsul(consulServer, consulKafkaServicename);
+            ArrayList<String> bootstrapServersArray = getBootStrapServersFromConsul(consulServerUrl, consulKafkaServicename);
             if (bootstrapServersArray != null) {
                 String bootstrapServers = String.join(",", bootstrapServersArray);
                 if (bootstrapServers != null && !bootstrapServers.equals("")) {
@@ -65,6 +65,8 @@ public class PropertyConfig {
                     LOG.info("CONSUL: \"bootstrap.servers\" property value has been set to: [" + bootstrapServers + "]");
                 }
             }
+        } else {
+            LOG.info("CONSUL: Not found required properties for using Consul service discovery");
         }
     }
 

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -17,7 +17,7 @@ import com.orbitz.consul.HealthClient;
 import com.orbitz.consul.model.health.ServiceHealth;
 
 public class PropertyConfig {
-    private static final Logger LOG = LoggerFactory.getLogger(ConsumerThread.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PropertyConfig.class);
 
     public enum Constants {
         CONSUL_SERVER("consul.server"),

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -59,7 +59,8 @@ public class PropertyConfig {
             if (bootstrapServersArray != null) {
                 String bootstrapServers = String.join(",", bootstrapServersArray);
                 if (bootstrapServers != null && !bootstrapServers.equals("")) {
-                    LOG.info("CONSUL: \"bootstrap.servers\" property value was: [" + bootstrapServers + "]");
+                    String originalBootstrapServers = originalProps.getProperty(Constants.BOOTSTRAP_SERVERS.key);
+                    LOG.info("CONSUL: \"bootstrap.servers\" property value was: [" + originalBootstrapServers + "]");
                     originalProps.setProperty(Constants.BOOTSTRAP_SERVERS.key, bootstrapServers);
                     LOG.info("CONSUL: \"bootstrap.servers\" property value has been set to: [" + bootstrapServers + "]");
                 }

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -7,7 +7,12 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class PropertyConfig {
+    private static final Logger LOG = LoggerFactory.getLogger(ConsumerThread.class);
+
     public enum Constants {
         EXPORTER_PORT("exporter.port"),
         EXPORTER_METRIC_EXPIRE("exporter.metric.expire.seconds"),

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -56,6 +56,11 @@ public class PropertyConfig {
         String consulKafkaServicename = originalProps.getProperty(Constants.CONSUL_KAFKA_SERVICENAME.key);
 
         if (consulServer != null && consulKafkaServicename != null) {
+            LOG.info("Required properties for Consul discovery have been detected:"
+                    + " [ " 
+                    + Constants.CONSUL_SERVER.key + " : \"" + consulServer + "\", "
+                    + Constants.CONSUL_KAFKA_SERVICENAME.key + " : \"" + consulKafkaServicename + "\""
+                    + "]");
             String bootstrapServers = getBootStrapServersFromConsul(consulServer, consulKafkaServicename).toString();
             if (bootstrapServers != null && !bootstrapServers.equals("")) {
                 //originalProps.setProperty(Constants.BOOTSTRAP_SERVERS.key, bootstrapServers);

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -97,7 +97,7 @@ public class PropertyConfig {
         } catch (Exception e){
             LOG.error("CONSUL: " + e.toString());
         }
-        LOG.info("CONSUL: Kafka services found through Consul server: [" + (bootstrapServers==null?"None available":bootstrapServers.toString()) + "]");
+        LOG.info("CONSUL: Kafka services found through Consul server: " + (bootstrapServers==null?"None available":bootstrapServers.toString()));
         return bootstrapServers;
     }
 

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -46,10 +46,10 @@ public class PropertyConfig {
         props.put("enable.auto.commit", "false");
         props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         props.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
-        fixBootstrapServerIfConsulExists(props);
+        changeBootstrapServersIfConsulServerAvailable(props);
     }
 
-    void fixBootstrapServerIfConsulExists(Properties originalProps) {
+    void changeBootstrapServersIfConsulServerAvailable(Properties originalProps) {
         String consulServer = originalProps.getProperty(Constants.CONSUL_SERVER_URL.key);
         String consulKafkaServicename = originalProps.getProperty(Constants.CONSUL_KAFKA_SERVICENAME.key);
 

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -21,12 +21,6 @@ import com.orbitz.consul.model.health.ServiceHealth;
 public class PropertyConfig {
     private static final Logger LOG = LoggerFactory.getLogger(PropertyConfig.class);
 
-    public static String getPropertyAsString(Properties prop) {
-        StringWriter writer = new StringWriter();
-        prop.list(new PrintWriter(writer));
-        return writer.getBuffer().toString();
-    }
-
     public enum Constants {
         CONSUL_SERVER_URL("consul.server.url"),
         CONSUL_KAFKA_SERVICENAME("consul.kafka.servicename"),
@@ -54,9 +48,7 @@ public class PropertyConfig {
         props.put("enable.auto.commit", "false");
         props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         props.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
-        LOG.info("CONSUL: Before fixing bootstrap servers[\n" + getPropertyAsString(props) + "]");
         fixBootstrapServerIfConsulExists(props);
-        LOG.info("CONSUL: After fixing bootstrap servers[\n" + getPropertyAsString(props) + "]");
     }
 
     void fixBootstrapServerIfConsulExists(Properties originalProps) {
@@ -69,6 +61,7 @@ public class PropertyConfig {
             if (bootstrapServersArray != null) {
                 String bootstrapServers = String.join(",", bootstrapServersArray);
                 if (bootstrapServers != null && !bootstrapServers.equals("")) {
+                    LOG.info("CONSUL: \"bootstrap.servers\" property value was: [" + bootstrapServers + "]");
                     originalProps.setProperty(Constants.BOOTSTRAP_SERVERS.key, bootstrapServers);
                     LOG.info("CONSUL: \"bootstrap.servers\" property value has been set to: [" + bootstrapServers + "]");
                 }

--- a/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
+++ b/src/main/java/jp/gr/java_conf/ogibayashi/prometheus/PropertyConfig.java
@@ -3,6 +3,8 @@ package jp.gr.java_conf.ogibayashi.prometheus;
 import java.io.FileNotFoundException;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,12 @@ import com.orbitz.consul.model.health.ServiceHealth;
 
 public class PropertyConfig {
     private static final Logger LOG = LoggerFactory.getLogger(PropertyConfig.class);
+
+    public static String getPropertyAsString(Properties prop) {
+        StringWriter writer = new StringWriter();
+        prop.list(new PrintWriter(writer));
+        return writer.getBuffer().toString();
+    }
 
     public enum Constants {
         CONSUL_SERVER("consul.server"),
@@ -46,9 +54,9 @@ public class PropertyConfig {
         props.put("enable.auto.commit", "false");
         props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         props.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
-        LOG.info("Before fixing bootstrap servers[" + props.toString() + "]");
+        LOG.info("CONSUL: Before fixing bootstrap servers[\n" + getPropertyAsString(props) + "]");
         fixBootstrapServerIfConsulExists(props);
-        LOG.info("After fixing bootstrap servers[" + props.toString() + "]");
+        LOG.info("CONSUL: After fixing bootstrap servers[\n" + getPropertyAsString(props) + "]");
     }
 
     void fixBootstrapServerIfConsulExists(Properties originalProps) {
@@ -84,7 +92,7 @@ public class PropertyConfig {
             }
             bootstrapServers.add(address + ":" + port);
         }
-        LOG.info("Kafka server found through Consul: " + bootstrapServers.toString());
+        LOG.info("CONSUL: Kafka services found through Consul server: [" + (bootstrapServers==null?"None available":bootstrapServers.toString()) + "]");
         return bootstrapServers;
     }
 


### PR DESCRIPTION
It has been added a new **optional** functionality for allowing to use a _Consul_ service for discovering the available _Kafka_ servers.

This new functionality requires a new Consul client library (added in `pom.xml` file), and two new properties in the configuration file (`consul.server.url` and `consul.kafka.servicename`):

New library from: https://github.com/rickfast/consul-client

Example of new properties:
>\# Consul server URL (including protocol: http/https)
consul.server.url=http://localhost:8500
>
>\# Consul service name for filtering the Kafka service
consul.kafka.servicename=kafka

If these two variable exist and the _Consul_ service respond some valid information, and only in this case, the retrieved information will overwrite the previous existing property called `bootstrap.servers`.